### PR TITLE
Fix SIGSEGV (exit 139) on second in-job invocation: atomic jemalloc relocate

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -8,6 +8,55 @@ on:
       - main
 
 jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: ShellCheck relocate scripts and tests
+        run: |
+          shellcheck scripts/linux/relocate.sh scripts/mac/relocate.sh tests/relocate_test.sh
+
+      - name: Run relocate unit tests
+        run: |
+          bash tests/relocate_test.sh
+
+  linux_double_invocation:
+    # Regression guard for issue #5: invoking the action twice in one job used
+    # to SIGSEGV (exit 139) at the relocate step on the second invocation,
+    # because LD_PRELOAD pointed at the library being copied in place. Both
+    # invocations and their workloads must now succeed.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run jemalloc action (1st invocation - installs + populates cache)
+        uses: ./
+
+      - name: Workload after 1st invocation
+        run: |
+          echo "LD_PRELOAD=$LD_PRELOAD"
+          nohup bash -c 'while true; do sleep 10; done' > nohup.out 2> nohup.err < /dev/null &
+          echo $! > pid1
+          ./scripts/linux/verify.sh "$(cat pid1)"
+
+      - name: Run jemalloc action (2nd invocation - cache hit -> relocate step)
+        uses: ./
+
+      - name: Workload after 2nd invocation (never reached before the fix)
+        run: |
+          echo "LD_PRELOAD=$LD_PRELOAD"
+          nohup bash -c 'while true; do sleep 10; done' > nohup.out 2> nohup.err < /dev/null &
+          echo $! > pid2
+          ./scripts/linux/verify.sh "$(cat pid2)"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          for f in pid1 pid2; do
+            [ -f "$f" ] && { kill "$(cat "$f")" 2>/dev/null || true; rm -f "$f"; }
+          done
+
 #  mac:
 #    runs-on: macos-latest
 #    steps:

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -43,6 +43,18 @@ jobs:
       - name: Run jemalloc action (2nd invocation - cache hit -> relocate step)
         uses: ./
 
+      - name: Assert 1st-invocation process survived the relocate
+        run: |
+          # pid1 has libjemalloc.so.2 mapped via LD_PRELOAD. The old bug
+          # truncated that library in place during the 2nd invocation's
+          # relocate step, taking the process (and the copy) down with it.
+          # It must still be alive and still using jemalloc afterwards.
+          if ! kill -0 "$(cat pid1)" 2>/dev/null; then
+            echo "::error::pid1 (jemalloc-preloaded) died across the 2nd invocation - regression of #5"
+            exit 1
+          fi
+          ./scripts/linux/verify.sh "$(cat pid1)"
+
       - name: Workload after 2nd invocation (never reached before the fix)
         run: |
           echo "LD_PRELOAD=$LD_PRELOAD"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ jobs:
     
 ```
 
+## Re-invoking within a job
+
+The action is safe to invoke more than once in the same job. Installs are atomic
+and idempotent, so a later invocation will not disturb the `jemalloc` library
+already preloaded into running processes.
+
 ## Inputs
 | Argument | Description | Default | Required |
 |----------|-------------|---------|---------|

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
     # Add typical environment setup steps for node/java/python etc before jemalloc
     
     - name: Set up jemalloc
-      uses: kaeawc/setup-jemalloc@v0.0.2
+      uses: kaeawc/setup-jemalloc@v0.0.3
 
     # Any processes run (bash, java, golang, python, etc) will benefit from using jemalloc automatically.
     - name: Build Application

--- a/action.yml
+++ b/action.yml
@@ -25,12 +25,13 @@ runs:
       if: ${{ runner.os == 'Linux' && steps.cache-jemalloc.outputs.cache-hit == 'true' }}
       shell: bash
       run: |
+        # Atomic, idempotent install so a second in-job invocation cannot
+        # truncate an LD_PRELOAD'd / DYLD_INSERT_LIBRARIES'd library in place
+        # and crash the copy with SIGSEGV (issue #5).
         if [ "${{ runner.os }}" == "Linux" ]; then
-          mkdir -p /usr/local/lib
-          sudo cp /tmp/libjemalloc.so.2 /usr/local/lib/
+          bash "${{ github.action_path }}/scripts/linux/relocate.sh" /tmp/libjemalloc.so.2 /usr/local/lib/libjemalloc.so.2
         elif [ "${{ runner.os }}" == "macOS" ]; then
-          sudo mkdir -p /opt/homebrew/Cellar/jemalloc/5.3.0/lib
-          sudo cp /tmp/libjemalloc.2.dylib /opt/homebrew/Cellar/jemalloc/5.3.0/lib/
+          bash "${{ github.action_path }}/scripts/mac/relocate.sh" /tmp/libjemalloc.2.dylib /opt/homebrew/Cellar/jemalloc/5.3.0/lib/libjemalloc.2.dylib
         elif [ "${{ runner.os }}" == "Windows" ]; then
           mkdir -p "$RUNNER_TEMP/jemalloc"
           cp /tmp/libjemalloc.dll "$RUNNER_TEMP/jemalloc/jemalloc.dll"

--- a/scripts/linux/relocate.sh
+++ b/scripts/linux/relocate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Atomically install the jemalloc shared library into its expected location.
+#
+# Why this exists (issue #5): the action persists LD_PRELOAD=<dest> into
+# $GITHUB_ENV, so on a second in-job invocation `dest` is mapped into every
+# running process — including the very tool doing the copy. A plain
+# `cp src dest` opens the destination O_TRUNC and rewrites it in place, which
+# truncates that live-mapped shared object out from under those processes and
+# crashes them with SIGSEGV (exit 139).
+#
+# The fix: write to a temp file in the destination directory and rename(2) it
+# over the target. rename() atomically swaps the directory entry while any
+# process that already mapped the old inode keeps reading it unharmed. We also
+# short-circuit when the destination already byte-matches the source, so an
+# idempotent re-invocation never touches a mapped library at all.
+#
+# SUDO is overridable (e.g. SUDO="" in unit tests) so the logic can run
+# unprivileged against scratch paths.
+
+SUDO="${SUDO-sudo}"
+
+# relocate_jemalloc <src> <dest>
+relocate_jemalloc() {
+  local src="$1"
+  local dest="$2"
+  local dest_dir
+  dest_dir="$(dirname "$dest")"
+
+  if [ ! -f "$src" ]; then
+    echo "Source library not found: $src" >&2
+    return 1
+  fi
+
+  $SUDO install -d "$dest_dir" || return 1
+
+  # Idempotent: destination already correct -> do not touch a possibly-mapped lib.
+  if [ -f "$dest" ] && cmp -s "$src" "$dest"; then
+    echo "jemalloc already in place at $dest; skipping relocate"
+    return 0
+  fi
+
+  # Atomic replace via a temp file in the same directory + rename(2).
+  local tmp
+  tmp="$($SUDO mktemp "${dest}.XXXXXX")" || return 1
+  if ! $SUDO cp "$src" "$tmp"; then
+    $SUDO rm -f "$tmp"
+    return 1
+  fi
+  # mktemp creates 0600; restore the world-readable 0755 that `make install`
+  # gives the shared object so a non-root workload can LD_PRELOAD it.
+  $SUDO chmod 0755 "$tmp" || { $SUDO rm -f "$tmp"; return 1; }
+  $SUDO mv -f "$tmp" "$dest" || { $SUDO rm -f "$tmp"; return 1; }
+  echo "Relocated jemalloc to $dest"
+}
+
+# Allow direct execution: scripts/linux/relocate.sh <src> <dest>
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+  set -euo pipefail
+  relocate_jemalloc "$@"
+fi

--- a/scripts/mac/relocate.sh
+++ b/scripts/mac/relocate.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Atomically install the jemalloc dylib into its expected location on macOS.
+#
+# Same hazard as the Linux path (issue #5): the action persists
+# DYLD_INSERT_LIBRARIES=<dest>, so a second in-job invocation would `cp` in
+# place over a dylib that is mapped into running processes. rename(2) keeps the
+# old inode alive for anything that already mapped it; an idempotent match
+# skips the copy entirely.
+#
+# SUDO is overridable (e.g. SUDO="" in unit tests) so the logic can run
+# unprivileged against scratch paths.
+
+SUDO="${SUDO-sudo}"
+
+# relocate_jemalloc <src> <dest>
+relocate_jemalloc() {
+  local src="$1"
+  local dest="$2"
+  local dest_dir
+  dest_dir="$(dirname "$dest")"
+
+  if [ ! -f "$src" ]; then
+    echo "Source library not found: $src" >&2
+    return 1
+  fi
+
+  $SUDO install -d "$dest_dir" || return 1
+
+  if [ -f "$dest" ] && cmp -s "$src" "$dest"; then
+    echo "jemalloc already in place at $dest; skipping relocate"
+    return 0
+  fi
+
+  local tmp
+  tmp="$($SUDO mktemp "${dest}.XXXXXX")" || return 1
+  if ! $SUDO cp "$src" "$tmp"; then
+    $SUDO rm -f "$tmp"
+    return 1
+  fi
+  # mktemp creates 0600; restore world-readable 0755 so a non-root workload
+  # can map the dylib via DYLD_INSERT_LIBRARIES.
+  $SUDO chmod 0755 "$tmp" || { $SUDO rm -f "$tmp"; return 1; }
+  $SUDO mv -f "$tmp" "$dest" || { $SUDO rm -f "$tmp"; return 1; }
+  echo "Relocated jemalloc to $dest"
+}
+
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+  set -euo pipefail
+  relocate_jemalloc "$@"
+fi

--- a/tests/relocate_test.sh
+++ b/tests/relocate_test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090  # relocate scripts are sourced via known-constant path vars
+#
+# Unit tests for the jemalloc relocate scripts (issue #5).
+#
+# These tests are dependency-free (no bats) so they run identically on a dev
+# machine and on a bare CI runner. They exercise the relocate logic without
+# sudo by exporting SUDO="" and operating inside a scratch directory.
+#
+# Each test maps to an evaluation criterion in PLAN.md (EC1..EC5).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LINUX_RELOCATE="$REPO_ROOT/scripts/linux/relocate.sh"
+MAC_RELOCATE="$REPO_ROOT/scripts/mac/relocate.sh"
+
+export SUDO=""
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+pass() { PASS=$((PASS + 1)); echo "ok   - $1"; }
+fail() { FAIL=$((FAIL + 1)); FAILED_NAMES+=("$1"); echo "FAIL - $1: ${2:-}"; }
+
+# assert_eq <name> <expected> <actual>
+assert_eq() {
+  if [ "$2" == "$3" ]; then pass "$1"; else fail "$1" "expected '$2' got '$3'"; fi
+}
+
+new_workdir() {
+  mktemp -d "${TMPDIR:-/tmp}/relocate_test.XXXXXX"
+}
+
+# ---------------------------------------------------------------------------
+# EC1 — Fresh install into a missing destination dir
+# ---------------------------------------------------------------------------
+test_fresh_install() {
+  local wd src dest
+  wd="$(new_workdir)"
+  src="$wd/src.so"
+  dest="$wd/libdir/libjemalloc.so.2"   # libdir does not exist yet
+  printf 'NEWLIB' > "$src"
+
+  if ( . "$LINUX_RELOCATE"; relocate_jemalloc "$src" "$dest" ) >/dev/null 2>&1; then
+    if [ -f "$dest" ] && cmp -s "$src" "$dest"; then
+      pass "EC1 fresh install copies file and creates dir"
+    else
+      fail "EC1 fresh install copies file and creates dir" "dest missing or mismatched"
+    fi
+  else
+    fail "EC1 fresh install copies file and creates dir" "relocate returned non-zero"
+  fi
+  rm -rf "$wd"
+}
+
+# ---------------------------------------------------------------------------
+# EC2 — Idempotent skip when destination already matches (inode unchanged)
+# ---------------------------------------------------------------------------
+test_idempotent_skip() {
+  local wd src dest ino_before ino_after
+  wd="$(new_workdir)"
+  src="$wd/src.so"
+  dest="$wd/lib/libjemalloc.so.2"
+  mkdir -p "$wd/lib"
+  printf 'SAME' > "$src"
+  cp "$src" "$dest"
+  ino_before="$(stat -f '%i' "$dest" 2>/dev/null || stat -c '%i' "$dest")"
+
+  ( . "$LINUX_RELOCATE"; relocate_jemalloc "$src" "$dest" ) >/dev/null 2>&1
+  ino_after="$(stat -f '%i' "$dest" 2>/dev/null || stat -c '%i' "$dest")"
+
+  assert_eq "EC2 idempotent skip leaves inode unchanged" "$ino_before" "$ino_after"
+  rm -rf "$wd"
+}
+
+# ---------------------------------------------------------------------------
+# EC3 — Atomic replace preserves the old inode for a process holding it open.
+#       This is the direct regression guard for the exit-139 SIGSEGV: a live
+#       mmap/open fd on the old library must NOT be truncated in place.
+# ---------------------------------------------------------------------------
+test_atomic_replace_preserves_open_fd() {
+  local wd src dest via_fd
+  wd="$(new_workdir)"
+  src="$wd/src.so"
+  dest="$wd/lib/libjemalloc.so.2"
+  mkdir -p "$wd/lib"
+  printf 'OLDBYTES' > "$dest"
+  printf 'NEWBYTES' > "$src"
+
+  # Open a long-lived fd on the destination BEFORE relocating (stands in for a
+  # process that has LD_PRELOAD'd / mmap'd the old library).
+  exec 9<"$dest"
+  ( . "$LINUX_RELOCATE"; relocate_jemalloc "$src" "$dest" ) >/dev/null 2>&1
+  # Read what the still-open fd sees. With an atomic rename the old inode is
+  # intact ("OLDBYTES"). With an in-place truncating cp it would be clobbered.
+  via_fd="$(cat <&9)"
+  exec 9<&-
+
+  assert_eq "EC3 open fd still sees old inode (no in-place truncate)" "OLDBYTES" "$via_fd"
+  rm -rf "$wd"
+}
+
+# ---------------------------------------------------------------------------
+# EC4 — After replacing a differing destination, dest matches the new source
+# ---------------------------------------------------------------------------
+test_content_updated() {
+  local wd src dest
+  wd="$(new_workdir)"
+  src="$wd/src.so"
+  dest="$wd/lib/libjemalloc.so.2"
+  mkdir -p "$wd/lib"
+  printf 'OLDBYTES' > "$dest"
+  printf 'NEWBYTES' > "$src"
+
+  ( . "$LINUX_RELOCATE"; relocate_jemalloc "$src" "$dest" ) >/dev/null 2>&1
+  if cmp -s "$src" "$dest"; then
+    pass "EC4 destination updated to new content"
+  else
+    fail "EC4 destination updated to new content" "dest does not match src"
+  fi
+  rm -rf "$wd"
+}
+
+# ---------------------------------------------------------------------------
+# EC5 — Missing source fails cleanly (non-zero, no destination created)
+# ---------------------------------------------------------------------------
+test_missing_source_fails() {
+  local wd dest rc
+  wd="$(new_workdir)"
+  dest="$wd/lib/libjemalloc.so.2"
+
+  if ( . "$LINUX_RELOCATE"; relocate_jemalloc "$wd/does-not-exist.so" "$dest" ) >/dev/null 2>&1; then
+    rc=0
+  else
+    rc=1
+  fi
+  if [ "$rc" -ne 0 ] && [ ! -f "$dest" ]; then
+    pass "EC5 missing source fails without creating destination"
+  else
+    fail "EC5 missing source fails without creating destination" "rc=$rc dest_exists=$([ -f "$dest" ] && echo yes || echo no)"
+  fi
+  rm -rf "$wd"
+}
+
+# ---------------------------------------------------------------------------
+# EC3 (mac parity) — same atomic guarantee for the dylib relocate script
+# ---------------------------------------------------------------------------
+test_mac_atomic_replace_preserves_open_fd() {
+  local wd src dest via_fd
+  wd="$(new_workdir)"
+  src="$wd/src.dylib"
+  dest="$wd/lib/libjemalloc.2.dylib"
+  mkdir -p "$wd/lib"
+  printf 'OLDDYLIB' > "$dest"
+  printf 'NEWDYLIB' > "$src"
+
+  exec 8<"$dest"
+  ( . "$MAC_RELOCATE"; relocate_jemalloc "$src" "$dest" ) >/dev/null 2>&1
+  via_fd="$(cat <&8)"
+  exec 8<&-
+
+  assert_eq "EC3-mac open fd still sees old inode (no in-place truncate)" "OLDDYLIB" "$via_fd"
+  rm -rf "$wd"
+}
+
+echo "== relocate unit tests =="
+test_fresh_install
+test_idempotent_skip
+test_atomic_replace_preserves_open_fd
+test_content_updated
+test_missing_source_fails
+test_mac_atomic_replace_preserves_open_fd
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -ne 0 ]; then
+  printf 'Failing: %s\n' "${FAILED_NAMES[@]}"
+  exit 1
+fi

--- a/tests/relocate_test.sh
+++ b/tests/relocate_test.sh
@@ -7,7 +7,10 @@
 # machine and on a bare CI runner. They exercise the relocate logic without
 # sudo by exporting SUDO="" and operating inside a scratch directory.
 #
-# Each test maps to an evaluation criterion in PLAN.md (EC1..EC5).
+# Each test is labelled with an evaluation criterion (EC1..EC5):
+#   EC1 fresh install, EC2 idempotent skip (inode unchanged), EC3 atomic
+#   replace preserves a live open fd (the SIGSEGV regression guard),
+#   EC4 content updated, EC5 missing source fails cleanly.
 
 set -uo pipefail
 


### PR DESCRIPTION
## Summary

Fixes #5 — a **SIGSEGV (exit 139)** crash on the **second invocation of the action in the same job** on Linux.

### Root cause
The first invocation persists `LD_PRELOAD=/usr/local/lib/libjemalloc.so.2` into `$GITHUB_ENV`, so it stays active for every later step. On a second invocation the cache hits and the *"Relocate jemalloc to expected directory"* step runs `sudo cp /tmp/libjemalloc.so.2 /usr/local/lib/`. `cp` opens the destination `O_TRUNC` and rewrites it **in place** — but that file is the very library `LD_PRELOAD`'d into the running `cp`. Truncating a live-mmap'd shared object corrupts `cp`'s own code pages → crash, before the caller's workload ever runs.

### Fix
Replace the in-place copy with an **atomic install**, extracted into testable scripts:

- `scripts/linux/relocate.sh` / `scripts/mac/relocate.sh`: copy to a temp file *in the destination directory*, then `mv -f` (rename(2)) over the target. rename() swaps the directory entry atomically while any process that already mapped the old inode keeps it intact.
- **Idempotent short-circuit**: if the destination already byte-matches the source, do nothing — never touch a possibly-mapped library.
- `action.yml` now calls these scripts instead of inlining `cp`.

This is exactly the fix suggested in the issue, applied to both the Linux and macOS relocate paths.

## Testing

Dependency-free unit tests (`tests/relocate_test.sh`, no bats required) mapped to explicit evaluation criteria:

| Test | Criterion |
|------|-----------|
| EC1 | Fresh install creates dir + copies file |
| EC2 | Idempotent skip leaves inode unchanged |
| EC3 | **Regression guard:** a process holding the old file open still reads the old inode after relocate (no in-place truncation) |
| EC4 | Destination updated to new content when it differs |
| EC5 | Missing source fails cleanly without creating a partial destination |
| EC3-mac | Same atomic guarantee for the dylib path |

CI additions in `.github/workflows/commit.yml`:
- `unit_tests` job: runs `shellcheck` + the unit tests.
- `linux_double_invocation` job: invokes the action **twice in one job** and runs a jemalloc-verified workload after each — the exact scenario that used to crash at invocation 2.

Locally: `shellcheck` clean, all 6 unit tests pass.

## Notes / follow-ups
- macOS relocate is fixed for parity but not exercised in CI (macOS is currently unsupported/disabled).
- A pre-existing hardcoded `5.3.0` in the macOS Cellar path (independent of the `jemalloc-version` input) will be filed as a separate follow-up.

Fixes #5
