### PR TITLE
bump version to v0.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
     # Add typical environment setup steps for node/java/python etc before jemalloc
     
     - name: Set up jemalloc
-      uses: kaeawc/setup-jemalloc@v0.0.4
+      uses: kaeawc/setup-jemalloc@v0.0.5
 
     # Any processes run (bash, java, golang, python, etc) will benefit from using jemalloc automatically.
     - name: Build Application


### PR DESCRIPTION
Bumps the README usage pin to `@v0.0.5` for the v0.0.5 release.

v0.0.5 tags current `main` so the published tag includes the #8 dead-code cleanup (#10) that landed after v0.0.4. No consumer-facing behavior change since v0.0.4 (same steps, same cache key).