### PR TITLE
Fix flaky EC2 inode check in relocate tests

### DIFF
--- a/tests/relocate_test.sh
+++ b/tests/relocate_test.sh
@@ -36,6 +36,15 @@ new_workdir() {
   mktemp -d "${TMPDIR:-/tmp}/relocate_test.XXXXXX"
 }
 
+# Portable inode number for a file. GNU `stat -c '%i'` and BSD `stat -f '%i'`
+# use incompatible flags. Try GNU first: on BSD/macOS `stat -c` is an unknown
+# option and fails cleanly, so we fall back to `-f`. (The reverse order is
+# unsafe — GNU `stat -f` *succeeds* in filesystem mode and prints free-space
+# stats that drift between calls, which made the EC2 inode check flaky.)
+inode_of() {
+  stat -c '%i' "$1" 2>/dev/null || stat -f '%i' "$1"
+}
+
 # ---------------------------------------------------------------------------
 # EC1 — Fresh install into a missing destination dir
 # ---------------------------------------------------------------------------
@@ -69,10 +78,10 @@ test_idempotent_skip() {
   mkdir -p "$wd/lib"
   printf 'SAME' > "$src"
   cp "$src" "$dest"
-  ino_before="$(stat -f '%i' "$dest" 2>/dev/null || stat -c '%i' "$dest")"
+  ino_before="$(inode_of "$dest")"
 
   ( . "$LINUX_RELOCATE"; relocate_jemalloc "$src" "$dest" ) >/dev/null 2>&1
-  ino_after="$(stat -f '%i' "$dest" 2>/dev/null || stat -c '%i' "$dest")"
+  ino_after="$(inode_of "$dest")"
 
   assert_eq "EC2 idempotent skip leaves inode unchanged" "$ino_before" "$ino_after"
   rm -rf "$wd"


### PR DESCRIPTION
## Problem

The `unit_tests` job went red on `main` (after PR #11) with:

```
FAIL - EC2 idempotent skip leaves inode unchanged
```

The EC2 test read the destination inode with `stat -f '%i' || stat -c '%i'` (BSD-first). On GNU/Linux, `stat -f` doesn't fail — it succeeds in **filesystem** mode and prints free-space statistics, which drift between the before/after calls as the runner's disk usage changes. So EC2 was comparing two filesystem snapshots, not two inode numbers, and failed intermittently. It passed on earlier runs only because free space happened to be identical across the two calls.

## Fix

Read the inode via a **GNU-first** helper: `stat -c '%i'` then fall back to BSD `-f`. `stat -c` is an unknown option on BSD/macOS and fails cleanly, so the ordering is safe on both platforms (the reverse is not, per above).

Test-only change; no action runtime code touched. Verified shellcheck-clean and with 20× stress runs on macOS (and it runs on Linux via CI here).